### PR TITLE
Add agent discovery support (Link headers, MD negotiation, well-known)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,19 @@
 [build.environment]
   NODE_VERSION = "22"
   BUN_VERSION = "1.3.13"
+
+# Markdown content negotiation for AI agents.
+# When a request sends `Accept: text/markdown`, the edge function returns
+# the markdown source instead of the HTML rendering. Browsers continue
+# to get HTML because their default Accept prefers text/html.
+[[edge_functions]]
+  function = "markdown-negotiation"
+  path = "/"
+
+[[edge_functions]]
+  function = "markdown-negotiation"
+  path = "/about"
+
+[[edge_functions]]
+  function = "markdown-negotiation"
+  path = "/about/"

--- a/netlify/edge-functions/markdown-negotiation.ts
+++ b/netlify/edge-functions/markdown-negotiation.ts
@@ -1,0 +1,61 @@
+import type { Context } from "https://edge.netlify.com";
+
+const ROUTE_TO_MARKDOWN: Record<string, string> = {
+  "/": "/cv.md",
+  "/about": "/about.md",
+  "/about/": "/about.md",
+};
+
+export default async (request: Request, context: Context): Promise<Response | void> => {
+  const url = new URL(request.url);
+  const target = ROUTE_TO_MARKDOWN[url.pathname];
+  if (!target) return;
+
+  if (request.method !== "GET" && request.method !== "HEAD") return;
+
+  const accept = request.headers.get("accept") || "";
+  if (!prefersMarkdown(accept)) return;
+
+  const mdResponse = await fetch(new URL(target, url.origin).toString(), {
+    headers: { accept: "text/markdown" },
+  });
+  if (!mdResponse.ok) return;
+
+  const body = request.method === "HEAD" ? null : await mdResponse.text();
+
+  const headers = new Headers({
+    "content-type": "text/markdown; charset=utf-8",
+    "vary": "Accept",
+    "cache-control": "public, max-age=3600, must-revalidate",
+    "x-markdown-source": target,
+    "link": [
+      `</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"`,
+      `</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"`,
+      `<${url.pathname}>; rel="canonical"`,
+    ].join(", "),
+  });
+
+  return new Response(body, { status: 200, headers });
+};
+
+function prefersMarkdown(accept: string): boolean {
+  if (!accept) return false;
+  const entries = accept
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [type, ...params] = entry.split(";").map((s) => s.trim());
+      const qParam = params.find((p) => p.startsWith("q="));
+      const q = qParam ? parseFloat(qParam.slice(2)) : 1;
+      return { type: type.toLowerCase(), q: Number.isFinite(q) ? q : 1 };
+    });
+
+  const md = entries.find((e) => e.type === "text/markdown" || e.type === "text/x-markdown");
+  if (!md || md.q === 0) return false;
+
+  const html = entries.find((e) => e.type === "text/html");
+  const htmlQ = html ? html.q : 0;
+
+  return md.q >= htmlQ;
+}

--- a/public/.well-known/agent-skills/cv-info/SKILL.md
+++ b/public/.well-known/agent-skills/cv-info/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: cv-info
+description: Retrieve CV, biography, experience, skills, and contact information for Mathieu Drouet, Head of Product based in Lille, France.
+version: 1.0.0
+license: CC-BY-4.0
+---
+
+# cv-info — Mathieu Drouet CV access
+
+Use this skill when an agent (or downstream user) wants to read, summarize, or answer questions about Mathieu Drouet — his professional experience, skills, current focus, or how to contact him.
+
+## When to use
+
+- A user asks about Mathieu Drouet's background, experience, or current role.
+- An agent needs a structured CV to evaluate a candidate or prepare an introduction.
+- A user wants to download the CV or get in touch.
+
+## How to use
+
+All resources are static, public, no authentication. Prefer Markdown for parsing; fall back to PDF only when a human-readable formatted version is needed.
+
+### 1. Full CV (Markdown)
+
+```
+GET https://cv.drouet.io/cv.md
+Accept: text/markdown
+```
+
+Returns the full CV in Markdown, with frontmatter (`name`, `title`, `description`, `theme`, `iconSet`). Inline icons follow the pattern `**carbon:icon-name**` and can be stripped or ignored — they are decorative.
+
+### 2. About / long-form bio (Markdown)
+
+```
+GET https://cv.drouet.io/about.md
+Accept: text/markdown
+```
+
+Returns Mathieu's longer-form positioning: AI-Augmented Delivery approach, what he does and does not do, what he is currently looking for.
+
+### 3. CV (PDF)
+
+```
+GET https://cv.drouet.io/cv_mathieu_drouet.pdf
+```
+
+Printable PDF version. Same content as `cv.md` but formatted.
+
+### 4. Homepage content negotiation
+
+```
+GET https://cv.drouet.io/
+Accept: text/markdown
+```
+
+When `Accept: text/markdown` is sent, the homepage returns the CV in Markdown instead of the HTML rendering. Browsers continue to get HTML.
+
+### 5. Contact
+
+- Email: `m@mdr.cool`
+- LinkedIn: https://www.linkedin.com/in/mathieudrouet/
+- The site exposes WebMCP tools (`open_contact_form`, `download_cv_pdf`, `get_cv_markdown`) via `navigator.modelContext` when loaded in a browser.
+
+## Content preferences
+
+Per `https://cv.drouet.io/robots.txt`:
+
+- `search=yes` — indexing for search is welcome.
+- `ai-train=no` — please do **not** use this content to train models.
+- `ai-input=yes` — using this content as live grounding (RAG, conversational answers) is welcome.
+
+## Notes for agents
+
+- Content is in French. The CV title and section headings are bilingual-friendly (English keywords are common).
+- The CV is updated by editing `src/content/cv/cv.md` in the repository and rebuilding; treat the Markdown URL as the authoritative version.

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2.0/index.json",
+  "version": "0.2.0",
+  "skills": [
+    {
+      "name": "cv-info",
+      "type": "instructions",
+      "description": "Retrieve CV, biography, experience, skills, and contact information for Mathieu Drouet, Head of Product based in Lille, France.",
+      "url": "https://cv.drouet.io/.well-known/agent-skills/cv-info/SKILL.md",
+      "sha256": "cf26157372280e0f87d244b619bb99582c7b623c624db8a41bd7b175effea01a"
+    }
+  ]
+}

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,50 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://cv.drouet.io/",
+      "service-doc": [
+        {
+          "href": "https://cv.drouet.io/cv.md",
+          "type": "text/markdown",
+          "title": "CV of Mathieu Drouet — full content in Markdown"
+        },
+        {
+          "href": "https://cv.drouet.io/about.md",
+          "type": "text/markdown",
+          "title": "About page in Markdown"
+        },
+        {
+          "href": "https://cv.drouet.io/llms.txt",
+          "type": "text/markdown",
+          "title": "LLM-facing site summary (llms.txt)"
+        }
+      ],
+      "describedby": [
+        {
+          "href": "https://cv.drouet.io/llms.txt",
+          "type": "text/markdown"
+        }
+      ],
+      "alternate": [
+        {
+          "href": "https://cv.drouet.io/cv_mathieu_drouet.pdf",
+          "type": "application/pdf",
+          "title": "CV in PDF format"
+        }
+      ],
+      "https://agentskills.io/rel/index": [
+        {
+          "href": "https://cv.drouet.io/.well-known/agent-skills/index.json",
+          "type": "application/json",
+          "title": "Agent skills discovery index"
+        }
+      ],
+      "sitemap": [
+        {
+          "href": "https://cv.drouet.io/sitemap.xml",
+          "type": "application/xml"
+        }
+      ]
+    }
+  ]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -29,9 +29,47 @@
 # HTML files - Short-term caching
 /*.html
   Cache-Control: public, max-age=3600, must-revalidate
-  
+
+# Markdown resources for AI agents
+/*.md
+  Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600, must-revalidate
+  Vary: Accept
+
+/llms.txt
+  Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600, must-revalidate
+
+# Well-known agent discovery resources (RFC 8615)
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; charset=utf-8
+  Cache-Control: public, max-age=3600, must-revalidate
+
+/.well-known/agent-skills/index.json
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: public, max-age=3600, must-revalidate
+
+/.well-known/agent-skills/*/SKILL.md
+  Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600, must-revalidate
+
+# Homepage — advertise agent discovery resources via Link (RFC 8288)
 /
   Cache-Control: public, max-age=3600, must-revalidate
+  Vary: Accept
+  Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"
+  Link: </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"
+  Link: </llms.txt>; rel="describedby"; type="text/markdown"
+  Link: </cv.md>; rel="alternate"; type="text/markdown"; title="CV in Markdown"
+  Link: </about.md>; rel="alternate"; type="text/markdown"; title="About in Markdown"
+  Link: </cv_mathieu_drouet.pdf>; rel="alternate"; type="application/pdf"; title="CV in PDF"
+  Link: </sitemap.xml>; rel="sitemap"; type="application/xml"
+
+/about
+  Cache-Control: public, max-age=3600, must-revalidate
+  Vary: Accept
+  Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"
+  Link: </about.md>; rel="alternate"; type="text/markdown"; title="About in Markdown"
 
 # Security Headers
 /*

--- a/public/about.md
+++ b/public/about.md
@@ -1,0 +1,44 @@
+# À propos
+
+## Head of Product. Discovery terrain. IA dans les vraies mains.
+
+Dix ans à construire des produits numériques B2B complexes — des plateformes DICOM en imagerie médicale aux outils métiers que personne ne photographie jamais sur LinkedIn. Le genre de produits où un bug coûte cher, où les utilisateurs sont des experts, et où la roadmap doit survivre à trois réorganisations.
+
+## Ce que je fais concrètement
+
+Je dirige des équipes produit dans des contextes où le code a dix ans, où les utilisateurs sont sur le terrain (pas en open space), et où "ajouter de l'IA" doit vouloir dire autre chose que coller un chatbot dans un coin d'écran.
+
+Mon quotidien ressemble à ça :
+
+- **Discovery terrain** — pas des interviews Zoom de 30 minutes, mais des journées entières avec les utilisateurs dans leur environnement réel. C'est long, c'est inconfortable, et c'est la seule chose qui marche.
+- **Modernisation de systèmes legacy** — décortiquer un monolithe PHP de 2014, comprendre pourquoi il existe, et le transformer sans casser les 200 clients qui en dépendent.
+- **Intégration IA dans des produits existants** — identifier les 3 endroits où un LLM crée une vraie valeur mesurable, et ignorer les 47 autres où il ne sert qu'à cocher une case roadmap.
+
+## AI-Augmented Delivery
+
+J'utilise Claude Code en production depuis son arrivée. Pas comme un gadget — comme un multiplicateur d'équipe. Specs, audits, prototypes, refactors massifs : le workflow a changé, les décisions humaines restent les mêmes. Ce site est codé comme ça. `regrets.app` aussi.
+
+L'IA augmente la vélocité, pas le jugement produit. Savoir quand l'utiliser — et quand couper court — fait toute la différence entre une équipe qui livre et une équipe qui s'enferme dans ses propres outils.
+
+## Ce que je ne fais pas
+
+- Pas de product management en chambre — sans terrain, pas de produit.
+- Pas de roadmap tirée d'un template Notion.
+- Pas de "on a mis de l'IA" pour faire plaisir au board.
+- Pas de frameworks appliqués mécaniquement (RICE, MoSCoW, Jobs-to-be-Done existent pour servir le produit, pas l'inverse).
+
+## Ce que je cherche maintenant
+
+Une grande partie de ma carrière s'est passée à gérer des situations de crise. Pas des crises dramatiques avec des sirènes — plutôt le quotidien de beaucoup d'entreprises tech : un produit mal défini depuis le début, une dette technique qui a été ignorée trop longtemps, une équipe qui s'est réorganisée trois fois en deux ans, un contexte où tout le monde est épuisé et où personne ne sait vraiment vers quoi on va.
+
+Je sais faire ça. Mais à un moment tu réalises que tu passes beaucoup d'énergie à réparer des choses qui n'auraient pas dû se casser.
+
+Ce que j'aspire à maintenant c'est des organisations où la direction fait confiance au produit, où les équipes ont le droit de bien faire les choses, et où on n'est pas constamment en train de rattraper le retard. Des contextes plus fluides — pas plus simples, pas sans problèmes, mais où l'énergie va dans la bonne direction.
+
+## En dehors du produit
+
+Photographie documentaire sur le temps long, musique expérimentale (l'écoute, parfois la pratique), permaculture appliquée à un vrai jardin, et un intérêt de fond pour les sciences politiques — parce que les produits ne naissent jamais dans un vide.
+
+Basé à Lille. Mobile sur Paris, la Belgique, le Canada. Ouvert aux missions de transformation produit, aux rôles de direction, et aux conversations intéressantes sans agenda commercial.
+
+[m@mdr.cool](mailto:m@mdr.cool) — [LinkedIn](https://linkedin.com/in/mathieudrouet) — [regrets.app](https://regrets.app/)

--- a/public/cv.md
+++ b/public/cv.md
@@ -1,0 +1,149 @@
+---
+name: "Mathieu Drouet"
+title: "Head of Product | AI-Augmented Delivery"
+description: "Product leader avec 10+ ans d'expérience en produits numériques B2B complexes. Spécialisé en discovery terrain, transformation de systèmes legacy et intégration IA dans des produits existants."
+iconSet: "carbon"
+theme: "lumon"
+
+---
+
+# Mathieu Drouet
+
+## **carbon:identification** Coordonnées
+
+**carbon:email** **Email:** m@mdr.cool
+**carbon:content-delivery-network** [**Portfolio**](https://cv.drouet.io)
+**carbon:application-web** [**Studio**](https://regrets.app/)
+**carbon:logo-linkedin** [**LinkedIn**](https://linkedin.com/in/mathieudrouet)
+**carbon:location-heart-filled** **Localisation:** Lille, France
+**carbon:rocket** **Mobilité:** Lille, Paris, Belgique, Canada
+
+## **carbon:gamification** Centres d'intérêt
+
+**carbon:camera-action** Photographie documentaire
+**carbon:music** Musique expérimentale
+**carbon:agriculture-analytics** Permaculture
+**carbon:policy** Sciences Politiques
+**carbon:ibm-engineering-systems-design-rhapsody** Design
+
+## Expériences
+
+### regrets.app
+**carbon:location-heart-filled** Full remote – 2025
+**Fondateur** | 2025 – en cours | [Company Link](https://regrets.app/)
+
+- Conception, développement et publication d'applications iOS, macOS et SaaS
+- Ulk — framework d'agents IA pour Claude Code (59+ agents, skills, rules)
+- Stack : Next.js, Astro, SwiftUI, TypeScript, Tailwind CSS, Bun
+
+### HEYA (Here You Art)
+**carbon:location-heart-filled** Bruxelles / full remote – 2025
+**Head of Product** | 2025 | [Company Link](https://hereyouart.com/)
+
+- Discovery complète : audit technique, analyse concurrentielle (12 plateformes), entretiens parties prenantes
+- Conception, architecture et développement en solo du MVP complet (profils, réseau, messagerie, offres, multilingue fr/nl/en) via Claude Code et [Ulk](https://izo.github.io/Ulk/), framework d'agents IA développé en propre — stack Next.js 15, TypeScript, Tailwind CSS, Drizzle ORM
+- Roadmap stratégique 24 mois (acquisition, rétention, monétisation)
+- Prototypage d'intégrations LLM (Llama, Mistral) pour enrichissement de profils et modération, conformité RGPD
+
+### CH-Studio × GE HealthCare
+**carbon:location-heart-filled** Lille / full remote – 2025
+**Senior Product Manager** | 2025 | [Company Link](https://chstudio.fr/project/plateforme-de-gestion-de-donnees-dicom/)
+
+- Audit stratégique d'une plateforme de gestion de données DICOM (imagerie médicale, 1100+ utilisateurs)
+- Livraison d'un plan de 50+ recommandations et d'une roadmap 18 mois
+
+### Groupe Actual
+**carbon:location-heart-filled** Paris / Laval / full remote – 2023–2024
+**Senior Product Manager** | 2023 – 2024 | [Company Link](https://www.groupeactual.eu/)
+
+- Conception et lancement d'un microservice de gestion des comptes épargne-temps pour 500+ entreprises — automatisation via API Urssaf/MSA
+- Transformation digitale d'une application DAF legacy (15 ans) vers architecture cloud-native — discovery auprès des DAF et RH terrain
+- Management d'équipes cross-fonctionnelles de 12 personnes, Agile/Scrum
+- Delivery de 8 releases majeures, priorisation par valeur business
+
+### Bookr.fm (Music Data Studio)
+**carbon:location-heart-filled** Lille / Bruxelles / Valencia / full remote – 2021–2024
+**Senior Product Manager** | 2021 – 2024 | [Company Link](https://bookr.fm/)
+
+- Stratégie produit end-to-end, de la discovery (programmateurs, directeurs artistiques) au lancement commercial
+- SaaS B2B pour la programmation artistique de festivals et salles de concert (40+ festivals en beta, 885K+ profils artistes)
+- Conception UX/UI et intégration API native (CRM, billetterie, comptabilité)
+
+### Fluidra (Blueriiot / Riiot Labs)
+**carbon:location-heart-filled** Liège / Barcelone / Valencia / full remote – 2018–2021
+**Senior Product Manager, IoT** | 2018 – 2021 | [Company Link](https://www.fluidra.com/)
+
+- Migration de l'application principale vers Flutter — développement cross-platform iOS/Android
+- Discovery terrain auprès des installateurs, techniciens de maintenance et distributeurs
+- Refonte UX complète, réduction du churn mesurée
+- Lancement sur le marché américain, management d'une équipe internationale de 8 personnes / 3 fuseaux horaires
+
+### Agences, ESN & Freelance
+**carbon:location-heart-filled** Lille / Paris / full remote – 2005–2020
+**Directeur de projet technique / Chef de projet digital** | 2005 – 2020 | [Company Link](#)
+
+- **Direction technique chez BETC** — pilotage de la refonte du site Crédit Agricole
+- **Direction de projet technique** pour le n°1 européen des services à la personne
+- **Chef de projet** — réseau social privé pour assistantes maternelles (UX/UI, coordination d'équipe, SPIP/PHP)
+- **Responsable technique à l'Université Catholique de Lille** — migration d'infrastructure, administration serveurs, enseignement Linux
+- **Contributeur au CMS open source SPIP** (jusqu'en 2020)
+- **Co-fondateur de Sacavin** (startup vin) et **Take a Sip** (agence de création de contenu)
+- Développement front-end, mentorat de projets mobiles/musique
+
+## Compétences
+
+### Product leadership **carbon:cognitive**
+**Strategic Leadership** | **carbon:badge** Expert
+
+- Discovery terrain, roadmap produit, go-to-market
+- OKR, priorisation par impact business
+- Delivery management, équipes cross-fonctionnelles
+
+### IA appliquée au produit **carbon:ai-generate**
+**AI Product** | **carbon:task-star** Avancé
+
+- Claude Code (usage quotidien), agents IA, Model Context Protocol (MCP)
+- LLM open source (Llama, Mistral, Claude), RAG, fine-tuning
+- Prototypage et intégration IA dans produits existants
+- [Ulk](https://izo.github.io/Ulk/) — framework d'agents développé en propre
+
+### Analytics **carbon:analytics**
+**Data-Driven** | **carbon:task-star** Avancé
+
+- PostHog, Hotjar, analyse comportementale
+- Feedback loops, KPI produit
+
+### Développement & infrastructure **carbon:edge-device**
+**Full-Stack Development** | **carbon:task-star** Avancé
+
+- Next.js, Astro, React, TypeScript, Tailwind CSS, Bun
+- Flutter, SwiftUI, SPIP, PHP, architecture API
+- CI/CD, Git, Linux, macOS avancé
+- Xcode (développement, distribution App Store / TestFlight)
+
+### Design & création **carbon:ibm-engineering-systems-design-rhapsody**
+**Creative Direction** | **carbon:task-star** Avancé
+
+- Figma, Adobe Creative Suite (Lightroom, Photoshop, InDesign — usage professionnel)
+- Direction artistique
+
+### Outils produit **carbon:branch**
+**Digital Workflow** | **carbon:badge** Expert
+
+- Linear, Notion, Obsidian, Jira, Confluence
+- Vercel, Cursor, Git, CI/CD, VS Code, Claude Code
+
+### Langues **carbon:ibm-watson-language-translator**
+**International Communication** | **carbon:task-star** Avancé
+
+- Français : langue maternelle
+- Anglais : professionnel courant
+- Espagnol : conversationnel
+
+## **carbon:airline-passenger-care** Education
+
+### Programmation iOS — SwiftUI
+Simplon.co, Lille – 2022–2023
+
+### Photographie documentaire
+Institut Supérieur d'Architecture Saint-Luc & ARIAP, Tournai - Lille – 1997–2001

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,32 @@
+# Mathieu Drouet — Head of Product
+
+> CV en ligne de Mathieu Drouet, Head of Product basé à Lille (France). 10+ ans d'expérience sur des produits numériques B2B complexes : discovery terrain, modernisation de systèmes legacy, intégration IA en production. Fondateur de regrets.app.
+
+Site : https://cv.drouet.io
+
+## Resources
+
+- [CV (Markdown)](https://cv.drouet.io/cv.md): CV complet en Markdown, mis à jour à chaque build.
+- [About (Markdown)](https://cv.drouet.io/about.md): Présentation longue : approche produit, AI-Augmented Delivery, ce que je cherche.
+- [CV (PDF)](https://cv.drouet.io/cv_mathieu_drouet.pdf): Version PDF imprimable du CV.
+- [API Catalog](https://cv.drouet.io/.well-known/api-catalog): Index machine-lisible des ressources publiées (RFC 9727).
+- [Agent Skills Index](https://cv.drouet.io/.well-known/agent-skills/index.json): Skills exposées pour les agents IA.
+
+## Profils externes
+
+- [LinkedIn](https://www.linkedin.com/in/mathieudrouet/)
+- [GitHub](https://github.com/izo)
+- [Portfolio](https://mathieu-drouet.com)
+- [regrets.app](https://regrets.app/)
+
+## Contact
+
+- Email : m@mdr.cool
+- Téléphone : +33 7 67 14 48 74
+- Localisation : Lille, France (mobile sur Paris, Belgique, Canada)
+
+## Préférences d'usage IA (Content Signals)
+
+- search=yes — indexation pour la recherche autorisée
+- ai-train=no — pas d'usage pour entraîner des modèles
+- ai-input=yes — utilisation comme contexte (grounding) autorisée

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,12 @@
 User-agent: *
 Allow: /
 
+# Content Signals (https://contentsignals.org/)
+# search=yes:    crawl for search indexing
+# ai-train=no:   do NOT use content to train AI models
+# ai-input=yes:  may use content as live grounding for AI answers
+Content-Signal: search=yes, ai-train=no, ai-input=yes
+
 # Sitemap
 Sitemap: https://cv.drouet.io/sitemap.xml
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,7 +37,13 @@ const fullImageUrl = new URL(image, siteConfig.url).href;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <link rel="canonical" href={canonicalUrl} />
-    
+
+    <!-- Agent discovery (RFC 8288 link relations) -->
+    <link rel="api-catalog" type="application/linkset+json" href="/.well-known/api-catalog" />
+    <link rel="describedby" type="text/markdown" href="/llms.txt" />
+    <link rel="alternate" type="text/markdown" href={Astro.url.pathname === '/about' ? '/about.md' : '/cv.md'} title="Markdown version" />
+    <link rel="alternate" type="application/pdf" href="/cv_mathieu_drouet.pdf" title="CV (PDF)" />
+
     <!-- SEO Meta Tags -->
     <meta name="author" content={siteConfig.author.name} />
     <meta name="keywords" content={siteConfig.seo.keywords.join(", ")} />
@@ -204,6 +210,72 @@ const fullImageUrl = new URL(image, siteConfig.url).href;
           window.__cvDebug.help();
         }
       }
+    </script>
+
+    <!-- WebMCP: expose site tools to AI agents (https://webmachinelearning.github.io/webmcp/) -->
+    <script is:inline>
+      (function registerWebMCPTools() {
+        if (typeof navigator === 'undefined') return;
+        var mc = navigator.modelContext;
+        if (!mc || typeof mc.provideContext !== 'function') return;
+
+        try {
+          mc.provideContext({
+            tools: [
+              {
+                name: 'get_cv_markdown',
+                description: "Fetch Mathieu Drouet's full CV (Head of Product, Lille, France) as Markdown.",
+                inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+                execute: async function () {
+                  var res = await fetch('/cv.md', { headers: { 'Accept': 'text/markdown' } });
+                  if (!res.ok) throw new Error('CV markdown unavailable (HTTP ' + res.status + ')');
+                  var markdown = await res.text();
+                  return { content: [{ type: 'text', text: markdown }] };
+                }
+              },
+              {
+                name: 'get_about_markdown',
+                description: "Fetch Mathieu Drouet's long-form about page (AI-Augmented Delivery, what he does and looks for) as Markdown.",
+                inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+                execute: async function () {
+                  var res = await fetch('/about.md', { headers: { 'Accept': 'text/markdown' } });
+                  if (!res.ok) throw new Error('About markdown unavailable (HTTP ' + res.status + ')');
+                  var markdown = await res.text();
+                  return { content: [{ type: 'text', text: markdown }] };
+                }
+              },
+              {
+                name: 'download_cv_pdf',
+                description: "Trigger a browser download of Mathieu Drouet's CV as a PDF file.",
+                inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+                execute: async function () {
+                  var a = document.createElement('a');
+                  a.href = '/cv_mathieu_drouet.pdf';
+                  a.download = 'CV-Mathieu-Drouet.pdf';
+                  document.body.appendChild(a);
+                  a.click();
+                  a.remove();
+                  return { content: [{ type: 'text', text: 'CV PDF download started.' }] };
+                }
+              },
+              {
+                name: 'open_contact_form',
+                description: "Open the contact form modal so the user can send a message to Mathieu Drouet.",
+                inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+                execute: async function () {
+                  if (typeof window.openContactModal === 'function') {
+                    window.openContactModal();
+                    return { content: [{ type: 'text', text: 'Contact form opened.' }] };
+                  }
+                  return { content: [{ type: 'text', text: 'Contact form is not available on this page.' }], isError: true };
+                }
+              }
+            ]
+          });
+        } catch (err) {
+          console.warn('WebMCP registration failed:', err);
+        }
+      })();
     </script>
     
 


### PR DESCRIPTION
## Summary

Make the CV site discoverable and consumable by AI agents. Adds the agent-discovery primitives that are relevant for a static personal CV (no protected APIs, no MCP server backend, so OAuth / MCP-server-card endpoints are intentionally not published).

### What's new

- **Link response headers (RFC 8288)** on `/` and `/about` in `public/_headers`, pointing to the api-catalog, agent skills index, `llms.txt`, markdown alternates, and the PDF.
- **Content Signals in `robots.txt`** — `Content-Signal: search=yes, ai-train=no, ai-input=yes`.
- **`/.well-known/api-catalog`** as `application/linkset+json` (RFC 9727 / RFC 9264) listing service-doc / describedby / alternate / agent-skills / sitemap links.
- **`/.well-known/agent-skills/index.json`** (Agent Skills Discovery v0.2.0) referencing **`/.well-known/agent-skills/cv-info/SKILL.md`** with its SHA-256.
- **Static `/cv.md`, `/about.md`, `/llms.txt`** served as `text/markdown; charset=utf-8` via `_headers`.
- **Netlify Edge Function** `markdown-negotiation` returns the markdown source on `/` and `/about` when the request sends `Accept: text/markdown`. Browsers keep getting HTML; `Vary: Accept` is set.
- **HTML `<link rel="api-catalog|describedby|alternate">`** in the `<head>` for clients that don't inspect HTTP headers.
- **WebMCP tools** registered via `navigator.modelContext.provideContext()` in `BaseLayout`: `get_cv_markdown`, `get_about_markdown`, `download_cv_pdf`, `open_contact_form`.

### Intentionally skipped

- **OAuth / OIDC discovery + Protected Resource metadata** — no protected APIs on this site.
- **MCP Server Card** — no MCP server backing this site; would be misleading to publish.

## Test plan

- [x] `bun run build` succeeds and copies `.well-known/`, `*.md`, `llms.txt` into `dist/`.
- [x] `bun test` — 38/38 pass.
- [x] `bun run astro check` — same error count as `main` (2 pre-existing errors, none new).
- [x] Local `bun run dev` returns expected content for `/robots.txt`, `/.well-known/api-catalog`, `/.well-known/agent-skills/index.json`, `/llms.txt`, `/cv.md`, and HTML `<head>` of `/` contains the new `<link>` tags.
- [ ] Post-deploy: verify Netlify serves `Link:` response headers on `/` and `/about` (curl `-I`).
- [ ] Post-deploy: verify edge function returns markdown when `Accept: text/markdown` is sent to `/` and `/about`, and HTML otherwise.
- [ ] Post-deploy: re-run isitagentready.com against `cv.drouet.io`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SqFgJt1jortQFt7mHQ1U4n)_