### PR TITLE
Migration Netlify → Cloudflare Pages (spec + implémentation)

### DIFF
--- a/.content-cache.json
+++ b/.content-cache.json
@@ -1,4 +1,0 @@
-{
-  "lastHash": "4257ec0e02764cc59050ac9be1fd80c86897de05923fc9bc6cd4dbd35c90131b",
-  "lastModified": "2026-05-01T17:57:50.091Z"
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Site web CV de Mathieu Drouet — Head of Product | AI-Augmented Delivery. Const
   - Responsive design with mobile-first approach
 - **Component Organization**:
   - `ExperienceCard.astro`: Work experience display with company links, roles, and descriptions (mobile responsive with flexbox)
-  - `ContactModal.astro`: Contact form modal using Netlify Forms (works in production only)
+  - `ContactModal.astro`: Contact form modal — submits to the Cloudflare Pages Function `/api/contact` (works in production / on `wrangler pages dev`)
   - `cv/CVCard.astro`: CV-specific card component with icon support
   - `cv/CVGrid.astro`: Grid layout system for CV sections
   - `cv/CVSection.astro`: Section headers with icons
@@ -38,7 +38,8 @@ Site web CV de Mathieu Drouet — Head of Product | AI-Augmented Delivery. Const
 
 ## Gotchas
 - **Fetch réseau au build** : `ExperienceCard.astro` et `CVCard.astro` fetchent des SVG depuis `api.iconify.design` pendant le build SSG — un timeout réseau fait échouer le build
-- **Formulaire de contact** : `ContactModal.astro` utilise Netlify Forms ; ne fonctionne pas en local ni hors Netlify
+- **Formulaire de contact** : `ContactModal.astro` poste vers la Pages Function `functions/api/contact.ts` (envoi email via Resend). Nécessite les secrets `RESEND_API_KEY` / `CONTACT_TO` côté Cloudflare ; ne fonctionne pas avec `astro dev` seul (utiliser `wrangler pages dev`)
+- **Pages Functions (Cloudflare)** : `functions/_middleware.ts` gère la négociation Markdown (`Accept: text/markdown`) et `functions/api/contact.ts` le formulaire. Le répertoire `functions/` n'est pas analysé par `astro check`. Migration documentée dans `docs/07-migration-cloudflare-pages-2026-05-29.md`. L'edge function Netlify (`netlify/edge-functions/`) et `netlify.toml` restent présents jusqu'au cutover DNS (rollback)
 - **Format Markdown strict** : `cvParser.ts` attend un format précis dans `cv.md` (icônes, rôles, périodes). Un écart de format drop silencieusement les entrées sans erreur
 - **Détection poste actuel** : `current: true` si la période contient l'année en cours (`new Date().getFullYear()`)
 - **Package manager : bun** — `bun install`, `bun run build`, `bun test`. Lock file : `bun.lockb`. Netlify utilise bun via `BUN_VERSION=1.3.13` dans `netlify.toml`.

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.6",
         "@astrojs/sitemap": "^3.6.0",
+        "@cloudflare/workers-types": "^4.20260529.1",
         "astro": "^6.1.9",
         "tailwindcss": "^4.1.11",
         "typescript": "^6.0.0",
@@ -73,6 +74,8 @@
     "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260529.1", "", {}, "sha512-33n3nsaWELSgn4DLKj1X9dwZc3kVDnO+jF/hLH9fdaXG9mQzKDeUkQaVRWLJXvrPXPa9RaIuSAFO4Zh9YOqOog=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 

--- a/docs/00-index-2026-04-10.md
+++ b/docs/00-index-2026-04-10.md
@@ -23,6 +23,7 @@ tags: [reverse-doc, index]
 | 04 | [User Stories](04-user-stories-2026-04-10.md) | Epics et user stories reconstitués avec critères d'acceptation | 258 |
 | 05 | [Glossaire](05-glossaire-2026-04-10.md) | Termes métier, techniques, abréviations | 73 |
 | 06 | [Architecture](06-architecture-2026-04-10.md) | ADR reconstitués, diagrammes, composants | 219 |
+| 07 | [Migration Cloudflare Pages](07-migration-cloudflare-pages-2026-05-29.md) | Spécification de migration Netlify → Cloudflare Pages | — |
 
 ## Méthodologie
 

--- a/docs/07-migration-cloudflare-pages-2026-05-29.md
+++ b/docs/07-migration-cloudflare-pages-2026-05-29.md
@@ -1,0 +1,406 @@
+---
+title: Spécification de migration — Netlify → Cloudflare Pages
+type: spec
+category: migration
+date: 2026-05-29
+status: proposed
+author: claude
+tags: [migration, cloudflare, pages, netlify, infra]
+source: code-analysis
+---
+
+# Spécification de migration — Netlify → Cloudflare Pages
+
+> Document de spécification rédigé le 2026-05-29.
+> Cible : héberger le CV de Mathieu Drouet (`cv.drouet.io`) sur **Cloudflare Pages**
+> à la place de **Netlify**, à iso-fonctionnalité.
+
+## 1. Contexte et objectifs
+
+### 1.1 Situation actuelle
+
+Le site est un **site statique Astro (SSG)**, déployé sur **Netlify**. Le build
+produit un répertoire `dist/` servi tel quel par le CDN Netlify. Trois
+fonctionnalités reposent sur des primitives spécifiques à Netlify :
+
+| # | Fonctionnalité Netlify | Fichier | Criticité |
+|---|------------------------|---------|-----------|
+| F1 | Configuration de build | `netlify.toml` | Bloquant |
+| F2 | Edge Function de négociation Markdown (`Accept: text/markdown`) | `netlify/edge-functions/markdown-negotiation.ts` | Important |
+| F3 | Formulaire de contact (Netlify Forms) | `src/components/ContactModal.astro` | Important |
+| F4 | Headers cache + sécurité + CSP | `public/_headers` | Bloquant |
+
+Tout le reste (génération SSG, assets, sitemap, `.well-known`, `robots.txt`,
+service worker kill-switch) est agnostique de l'hébergeur.
+
+### 1.2 Objectifs de la migration
+
+- **O1** : Déployer le même `dist/` sur Cloudflare Pages, build via `bun`.
+- **O2** : Conserver la négociation de contenu Markdown pour les agents IA (F2).
+- **O3** : Conserver un formulaire de contact fonctionnel (F3) — sans Netlify Forms.
+- **O4** : Conserver tous les headers (cache, sécurité, CSP, Link RFC 8288) (F4).
+- **O5** : Basculer `cv.drouet.io` sans interruption de service ni perte SEO.
+- **O6** : Pouvoir revenir à Netlify en < 15 min (rollback).
+
+### 1.3 Hors périmètre
+
+- Refonte du design ou du contenu du CV.
+- Changement de framework (reste Astro SSG).
+- Migration des emails / DNS non liés au site (MX, etc.).
+
+## 2. Analyse de compatibilité Netlify → Cloudflare Pages
+
+| Primitive Netlify | Équivalent Cloudflare Pages | Effort | Compatibilité |
+|-------------------|-----------------------------|--------|---------------|
+| `netlify.toml` (`build`, `publish`) | Réglages projet (dashboard) ou `wrangler.toml` | Faible | Reconfiguration |
+| `[build.environment]` (NODE/BUN_VERSION) | Variables d'env de build + détection `bun.lock` | Faible | Reconfiguration |
+| `public/_headers` | `_headers` (**format identique**) | Nul | ✅ Natif |
+| `_redirects` (absent ici) | `_redirects` (format identique) | Nul | ✅ Natif |
+| Edge Functions (Deno, `https://edge.netlify.com`) | **Pages Functions** (Workers runtime, `functions/`) | Moyen | Réécriture |
+| Netlify Forms (`data-netlify`) | Aucun équivalent natif → **Pages Function + service tiers** | Moyen | Remplacement |
+| Déploiement sur push `main` | Intégration Git Cloudflare (build automatique) | Faible | Reconfiguration |
+
+**Conclusion** : la migration est réaliste. Les deux seuls vrais chantiers de
+code sont **F2** (Edge Function → Pages Function) et **F3** (Netlify Forms →
+solution alternative).
+
+## 3. Spécification détaillée
+
+### 3.1 Build et configuration projet (F1)
+
+Cloudflare Pages détecte `bun.lock` et installe les dépendances avec `bun`.
+Réglages à configurer dans le dashboard Cloudflare Pages (ou via `wrangler.toml`) :
+
+| Réglage | Valeur |
+|---------|--------|
+| Framework preset | `Astro` (ou `None`) |
+| Build command | `bun run build` |
+| Build output directory | `dist` |
+| Root directory | `/` |
+| Node version (env) | `NODE_VERSION=22` |
+
+> **Note bun** : Cloudflare Pages utilise `bun install` automatiquement si
+> `bun.lock` est présent. Pour forcer une version, définir la variable
+> d'environnement de build correspondante. Si la détection échoue, fallback
+> possible : `npm`/`pnpm` via le lockfile correspondant — éviter d'avoir
+> plusieurs lockfiles concurrents au commit (`bun.lock` est la référence ;
+> `package-lock.json` et `pnpm-lock.yaml` présents dans le repo devraient être
+> retirés ou ignorés pour lever l'ambiguïté de détection).
+
+**Fichier optionnel `wrangler.toml`** (versionner la config de déploiement) :
+
+```toml
+name = "cv-mathieudrouet-2025"
+pages_build_output_dir = "dist"
+compatibility_date = "2026-05-29"
+compatibility_flags = ["nodejs_compat"]
+```
+
+### 3.2 Headers (F4)
+
+`public/_headers` est copié tel quel dans `dist/` au build et est **nativement
+supporté par Cloudflare Pages avec la même syntaxe**. Aucune modification
+fonctionnelle requise.
+
+Points de vigilance à valider après bascule :
+- Les règles `Cache-Control: immutable` sur `/_astro/*`, `/fonts/*`, `/images/*`,
+  `/logos/*`.
+- Le `Content-Type: text/markdown` + `Vary: Accept` sur `/*.md`.
+- Les en-têtes `Link:` (RFC 8288) sur `/` et `/about`.
+- La CSP complète (ligne `/*`). **Cloudflare n'injecte pas de CSP** ; celle du
+  projet reste seule maîtresse — la conserver à l'identique.
+
+> ⚠️ Cloudflare Pages applique aussi `_headers` aux réponses servies par les
+> Pages Functions selon les règles de précédence. Vérifier que le `Content-Type`
+> renvoyé par la Function de négociation Markdown (§3.3) n'est pas écrasé.
+
+### 3.3 Négociation de contenu Markdown (F2)
+
+**Comportement à préserver** : sur `GET /`, `GET /about`, `GET /about/`, si le
+header `Accept` préfère `text/markdown` (q ≥ q de `text/html`), renvoyer la
+source Markdown (`/cv.md` ou `/about.md`) au lieu du HTML, avec `Vary: Accept`,
+`x-markdown-source` et les `Link` d'agent discovery. Sinon, laisser passer le HTML.
+
+**Implémentation cible** : une **Pages Function** middleware. Cloudflare exécute
+les fichiers du répertoire `functions/` sur le runtime Workers. Un middleware
+`functions/_middleware.ts` intercepte toutes les routes et applique la logique.
+
+```ts
+// functions/_middleware.ts
+const ROUTE_TO_MARKDOWN: Record<string, string> = {
+  "/": "/cv.md",
+  "/about": "/about.md",
+  "/about/": "/about.md",
+};
+
+export const onRequest: PagesFunction = async (context) => {
+  const { request, next } = context;
+  const url = new URL(request.url);
+  const target = ROUTE_TO_MARKDOWN[url.pathname];
+
+  // Routes non concernées OU méthode non idempotente → pipeline normal
+  if (!target || (request.method !== "GET" && request.method !== "HEAD")) {
+    return next();
+  }
+
+  const accept = request.headers.get("accept") || "";
+  if (!prefersMarkdown(accept)) return next();
+
+  // Récupère l'asset statique .md servi par Pages
+  const mdResponse = await context.env.ASSETS.fetch(
+    new URL(target, url.origin).toString(),
+    { headers: { accept: "text/markdown" } },
+  );
+  if (!mdResponse.ok) return next();
+
+  const body = request.method === "HEAD" ? null : await mdResponse.text();
+  const headers = new Headers({
+    "content-type": "text/markdown; charset=utf-8",
+    "vary": "Accept",
+    "cache-control": "public, max-age=3600, must-revalidate",
+    "x-markdown-source": target,
+    "link": [
+      `</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"`,
+      `</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"`,
+      `<${url.pathname}>; rel="canonical"`,
+    ].join(", "),
+  });
+  return new Response(body, { status: 200, headers });
+};
+
+function prefersMarkdown(accept: string): boolean {
+  // logique identique à netlify/edge-functions/markdown-negotiation.ts
+  if (!accept) return false;
+  const entries = accept.split(",").map((e) => e.trim()).filter(Boolean).map((e) => {
+    const [type, ...params] = e.split(";").map((s) => s.trim());
+    const q = params.find((p) => p.startsWith("q="));
+    const qv = q ? parseFloat(q.slice(2)) : 1;
+    return { type: type.toLowerCase(), q: Number.isFinite(qv) ? qv : 1 };
+  });
+  const md = entries.find((e) => e.type === "text/markdown" || e.type === "text/x-markdown");
+  if (!md || md.q === 0) return false;
+  const html = entries.find((e) => e.type === "text/html");
+  return md.q >= (html ? html.q : 0);
+}
+```
+
+**Différences clés à connaître** :
+- Runtime **Workers** (V8), pas Deno → pas d'import `https://edge.netlify.com`,
+  on type avec `PagesFunction` (paquet `@cloudflare/workers-types`).
+- Accès aux assets statiques via `context.env.ASSETS.fetch(...)` (le binding
+  `ASSETS` est fourni automatiquement aux Pages Functions).
+- La logique métier (`prefersMarkdown`, table de routes, headers) est **portée
+  à l'identique** : aucun changement de comportement attendu.
+
+**Migration de fichiers** : créer `functions/_middleware.ts`, puis supprimer
+`netlify/edge-functions/markdown-negotiation.ts` une fois la bascule validée.
+
+### 3.4 Formulaire de contact (F3) — chantier le plus impactant
+
+Le `ContactModal.astro` utilise **Netlify Forms** (`data-netlify="true"`,
+`data-netlify-honeypot`, champ caché `form-name`, POST AJAX vers `/`). **Cette
+primitive n'existe pas sur Cloudflare Pages.** Options classées par effort :
+
+| Option | Description | Effort | Dépendance externe |
+|--------|-------------|--------|--------------------|
+| **A. Pages Function + Email (recommandé)** | `functions/api/contact.ts` reçoit le POST, valide, envoie un email via API (Resend / MailChannels / SMTP) | Moyen | Compte service email |
+| B. Service de formulaire tiers | Formspree / Web3Forms / Getform : changer l'`action` du form | Faible | Compte tiers, données chez un tiers |
+| C. Cloudflare Worker + KV/D1 | Stocker les soumissions + notification | Élevé | Surdimensionné pour un CV |
+
+**Recommandation : Option A** (cohérent avec l'écosystème Cloudflare, pas de
+dépendance lourde, données maîtrisées). Spec :
+
+```ts
+// functions/api/contact.ts
+interface Env { RESEND_API_KEY: string; CONTACT_TO: string; }
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  const form = await request.formData();
+
+  // Honeypot anti-spam (champ "bot-field" laissé vide par un humain)
+  if (form.get("bot-field")) return new Response("OK", { status: 200 });
+
+  const name = String(form.get("name") || "").slice(0, 200);
+  const email = String(form.get("email") || "").slice(0, 200);
+  const message = String(form.get("message") || "").slice(0, 5000);
+  if (!name || !email || !message) {
+    return new Response("Champs requis manquants", { status: 400 });
+  }
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      "authorization": `Bearer ${env.RESEND_API_KEY}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      from: "cv.drouet.io <noreply@drouet.io>",
+      to: env.CONTACT_TO,
+      reply_to: email,
+      subject: `Contact CV — ${name}`,
+      text: `De: ${name} <${email}>\n\n${message}`,
+    }),
+  });
+
+  return res.ok
+    ? new Response("OK", { status: 200 })
+    : new Response("Erreur d'envoi", { status: 502 });
+};
+```
+
+**Modifications côté `ContactModal.astro`** :
+- Retirer les attributs `data-netlify`, `data-netlify-honeypot` et le champ
+  caché `form-name` (spécifiques Netlify).
+- Conserver le champ honeypot `bot-field` (réutilisé par la Function).
+- Pointer la soumission AJAX vers `POST /api/contact` au lieu de `POST /`.
+- Conserver les états loading / success / error et l'auto-close (3 s).
+
+**Protection anti-spam recommandée** : ajouter **Cloudflare Turnstile** (gratuit,
+intégré) en complément du honeypot — vérification du token côté Function via
+`https://challenges.cloudflare.com/turnstile/v0/siteverify`. Si Turnstile est
+ajouté, mettre à jour la **CSP** (`script-src` + `frame-src` pour
+`https://challenges.cloudflare.com`).
+
+**Secrets** : `RESEND_API_KEY` et `CONTACT_TO` sont des **variables
+d'environnement / secrets** du projet Pages (jamais committés). Mettre à jour
+`.gitignore` n'est pas nécessaire (déjà couvert), mais documenter ces secrets
+dans le runbook.
+
+### 3.5 CSP
+
+La CSP actuelle (`public/_headers`, ligne `/*`) doit évoluer **uniquement si**
+on ajoute des origines externes :
+- Option B (formulaire tiers) → ajouter le domaine du service à `form-action` /
+  `connect-src`.
+- Turnstile → ajouter `https://challenges.cloudflare.com` à `script-src` et
+  `frame-src` (actuellement `frame-src 'none'`).
+
+Sans ces ajouts (Option A sans Turnstile), la CSP reste **inchangée** : le POST
+vers `/api/contact` est same-origin (`connect-src 'self'` et `form-action 'self'`
+déjà présents). ✅
+
+## 4. Plan de migration (étapes)
+
+### Phase 0 — Préparation (sans impact prod)
+1. Créer un compte / projet Cloudflare Pages relié au repo GitHub.
+2. Choisir l'option formulaire (recommandé : A + Turnstile) et provisionner les
+   secrets (`RESEND_API_KEY`, `CONTACT_TO`).
+3. Lever l'ambiguïté de lockfiles (garder `bun.lock`, retirer
+   `package-lock.json` / `pnpm-lock.yaml` du repo).
+
+### Phase 1 — Portage du code (sur cette branche)
+4. Créer `functions/_middleware.ts` (négociation Markdown, §3.3).
+5. Créer `functions/api/contact.ts` (formulaire, §3.4).
+6. Adapter `ContactModal.astro` (retirer Netlify Forms, cibler `/api/contact`).
+7. Ajouter `wrangler.toml` (optionnel mais recommandé).
+8. Ajouter `@cloudflare/workers-types` en devDependency pour typer les Functions.
+9. Mettre à jour la CSP si Turnstile / service tiers (§3.5).
+
+### Phase 2 — Déploiement de validation (preview)
+10. Push → build Cloudflare Pages sur l'URL `*.pages.dev` (preview).
+11. Tests d'acceptation (§6) sur l'URL preview, **avant** tout changement DNS.
+
+### Phase 3 — Bascule DNS (cutover)
+12. Ajouter `cv.drouet.io` comme **custom domain** sur le projet Pages.
+13. Pointer le DNS : si la zone `drouet.io` est déjà gérée par Cloudflare, créer
+    un CNAME `cv` → `<projet>.pages.dev` (proxifié). Sinon, déléguer la zone à
+    Cloudflare ou créer le CNAME chez le registrar courant.
+14. Attendre l'émission du certificat TLS Cloudflare et la propagation.
+15. Désactiver le déploiement automatique côté Netlify (éviter les double-builds)
+    une fois la prod confirmée stable.
+
+### Phase 4 — Nettoyage (post-validation, ≥ 1 semaine)
+16. Supprimer `netlify.toml` et `netlify/edge-functions/`.
+17. Mettre à jour la doc (`CLAUDE.md`, `README.md`, docs techniques) pour refléter
+    Cloudflare Pages.
+
+## 5. Risques et mitigations
+
+| # | Risque | Impact | Mitigation |
+|---|--------|--------|------------|
+| R1 | Détection bun échoue au build CF | Build KO | Forcer via env / framework preset ; supprimer lockfiles concurrents |
+| R2 | Précédence `_headers` vs Function écrase le `Content-Type` Markdown | F2 cassé | Tester `curl -H "Accept: text/markdown"` sur preview ; headers explicites dans la Response |
+| R3 | Perte des soumissions de contact pendant la bascule | Leads perdus | Valider F3 sur preview avant cutover ; garder Netlify actif en parallèle 1 semaine |
+| R4 | Régression SEO (canonical, sitemap, 404) | SEO | Comparer headers/`Link` prod vs preview ; vérifier `sitemap.xml` |
+| R5 | CSP trop stricte casse Turnstile / form tiers | Form KO | Mettre à jour CSP en même temps que l'ajout d'origine |
+| R6 | TTL DNS long → bascule lente | Indispo perçue | Réduire le TTL 24 h avant cutover |
+| R7 | Secrets formulaire mal configurés | Form 502 | Tester l'envoi réel sur preview avec secrets de prod |
+
+## 6. Critères d'acceptation (tests de bascule)
+
+À exécuter sur l'URL **preview** Cloudflare avant le cutover, puis re-vérifier en
+prod après bascule :
+
+- [ ] `GET /` renvoie le HTML du CV (statut 200, `Content-Type: text/html`).
+- [ ] `GET /` avec `Accept: text/markdown` renvoie `cv.md`
+      (`Content-Type: text/markdown`, `x-markdown-source: /cv.md`, `Vary: Accept`).
+- [ ] `GET /about` idem avec `about.md`.
+- [ ] `GET /cv.md` renvoie `text/markdown; charset=utf-8`.
+- [ ] `/_astro/*`, `/fonts/*`, `/logos/*` servis avec `Cache-Control: …immutable`.
+- [ ] En-têtes de sécurité présents (`X-Frame-Options`, `X-Content-Type-Options`,
+      `Referrer-Policy`, `Permissions-Policy`) et **CSP** identique à l'actuelle.
+- [ ] En-têtes `Link:` (api-catalog, agent-skills, llms.txt, alternate md/pdf,
+      sitemap) présents sur `/` et `/about`.
+- [ ] `/.well-known/api-catalog`, `/.well-known/agent-skills/index.json`,
+      `/.well-known/agent-skills/cv-info/SKILL.md` servis avec le bon `Content-Type`.
+- [ ] `/sitemap.xml` et `/robots.txt` accessibles et corrects.
+- [ ] Soumission du formulaire de contact → email reçu ; honeypot bloque les bots.
+- [ ] Une route inexistante renvoie une 404.
+- [ ] Service worker kill-switch (`/sw.js`) toujours servi.
+- [ ] Lighthouse / Core Web Vitals non régressés vs Netlify.
+
+Exemples de commandes de vérification :
+
+```bash
+# Négociation Markdown
+curl -sI -H "Accept: text/markdown" https://<preview>.pages.dev/ | grep -i "content-type\|x-markdown-source\|vary"
+# HTML par défaut
+curl -sI https://<preview>.pages.dev/ | grep -i "content-type"
+# Headers cache
+curl -sI https://<preview>.pages.dev/_astro/ | grep -i cache-control
+# CSP
+curl -sI https://<preview>.pages.dev/ | grep -i content-security-policy
+```
+
+## 7. Plan de rollback
+
+La bascule étant un simple changement DNS, le rollback est rapide :
+
+1. Re-pointer le CNAME `cv` vers Netlify (ou retirer le custom domain de Pages).
+2. Réactiver le build automatique Netlify si désactivé.
+3. Propagation DNS (TTL réduit en amont → quelques minutes).
+
+Le code Netlify (`netlify.toml`, edge function) n'est **supprimé qu'en Phase 4**,
+après une période de stabilité ≥ 1 semaine — garantissant un rollback sans
+restauration de fichiers pendant la fenêtre critique.
+
+## 8. Impact documentaire (à mettre à jour après migration)
+
+| Fichier | Modification |
+|---------|--------------|
+| `CLAUDE.md` | Remplacer mentions Netlify (déploiement, Forms, `BUN_VERSION` dans `netlify.toml`, `_headers`) par Cloudflare Pages / Pages Functions |
+| `README.md` | Section déploiement |
+| `docs/02-doc-technique-*.md` | Stack (Hébergement = Cloudflare Pages), §7 CI/CD, arborescence (`functions/`) |
+| `docs/06-architecture-*.md` | ADR « Hébergement » + diagrammes de flux (form, négociation md) |
+| `src/config/env.ts` | `API_BASE_URL` prod (déjà incorrect, cf. D9) à corriger vers `cv.drouet.io` |
+
+## 9. Récapitulatif des fichiers
+
+**À créer**
+- `functions/_middleware.ts` — négociation Markdown (remplace l'edge function).
+- `functions/api/contact.ts` — backend formulaire de contact.
+- `wrangler.toml` — config de déploiement Pages (optionnel).
+
+**À modifier**
+- `src/components/ContactModal.astro` — retrait Netlify Forms, cible `/api/contact`.
+- `public/_headers` — uniquement si CSP à étendre (Turnstile / tiers).
+- `package.json` — ajout `@cloudflare/workers-types` (devDependency).
+
+**À conserver tel quel**
+- `public/_headers` (format compatible), `dist/`, tout `src/` hors ContactModal,
+  `.well-known/`, `robots.txt`, `sitemap`, `sw.js`.
+
+**À supprimer (Phase 4 uniquement)**
+- `netlify.toml`
+- `netlify/edge-functions/markdown-negotiation.ts`
+- Lockfiles concurrents `package-lock.json` / `pnpm-lock.yaml` (Phase 0).

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,76 @@
+/// <reference types="@cloudflare/workers-types" />
+
+// Pages Function middleware — Markdown content negotiation for AI agents.
+// Ported from netlify/edge-functions/markdown-negotiation.ts (iso-comportement).
+// When a request to a mapped route sends `Accept: text/markdown` (with a quality
+// at least equal to text/html), the Markdown source is returned instead of the
+// HTML rendering. Browsers keep getting HTML because their default Accept prefers
+// text/html.
+
+const ROUTE_TO_MARKDOWN: Record<string, string> = {
+  "/": "/cv.md",
+  "/about": "/about.md",
+  "/about/": "/about.md",
+};
+
+export const onRequest: PagesFunction = async (context) => {
+  const { request, next, env } = context;
+  const url = new URL(request.url);
+  const target = ROUTE_TO_MARKDOWN[url.pathname];
+
+  // Route non concernée → pipeline normal (assets statiques / autres Functions)
+  if (!target) return next();
+
+  // Méthode non idempotente → laisser passer (ex: POST /)
+  if (request.method !== "GET" && request.method !== "HEAD") return next();
+
+  const accept = request.headers.get("accept") || "";
+  if (!prefersMarkdown(accept)) return next();
+
+  // Récupère l'asset statique .md servi par Pages via le binding ASSETS
+  const assets = (env as { ASSETS: Fetcher }).ASSETS;
+  const mdResponse = await assets.fetch(
+    new Request(new URL(target, url.origin).toString(), {
+      headers: { accept: "text/markdown" },
+    }),
+  );
+  if (!mdResponse.ok) return next();
+
+  const body = request.method === "HEAD" ? null : await mdResponse.text();
+
+  const headers = new Headers({
+    "content-type": "text/markdown; charset=utf-8",
+    "vary": "Accept",
+    "cache-control": "public, max-age=3600, must-revalidate",
+    "x-markdown-source": target,
+    "link": [
+      `</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"`,
+      `</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"`,
+      `<${url.pathname}>; rel="canonical"`,
+    ].join(", "),
+  });
+
+  return new Response(body, { status: 200, headers });
+};
+
+function prefersMarkdown(accept: string): boolean {
+  if (!accept) return false;
+  const entries = accept
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [type, ...params] = entry.split(";").map((s) => s.trim());
+      const qParam = params.find((p) => p.startsWith("q="));
+      const q = qParam ? parseFloat(qParam.slice(2)) : 1;
+      return { type: type.toLowerCase(), q: Number.isFinite(q) ? q : 1 };
+    });
+
+  const md = entries.find((e) => e.type === "text/markdown" || e.type === "text/x-markdown");
+  if (!md || md.q === 0) return false;
+
+  const html = entries.find((e) => e.type === "text/html");
+  const htmlQ = html ? html.q : 0;
+
+  return md.q >= htmlQ;
+}

--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -1,0 +1,72 @@
+/// <reference types="@cloudflare/workers-types" />
+
+// Pages Function — backend du formulaire de contact (remplace Netlify Forms).
+// Reçoit le POST du ContactModal, valide les champs, applique un honeypot
+// anti-spam, puis envoie un email via l'API Resend.
+//
+// Secrets / variables d'environnement à configurer côté Cloudflare Pages :
+//   - RESEND_API_KEY : clé API Resend (secret)
+//   - CONTACT_TO     : adresse email destinataire
+//   - CONTACT_FROM   : expéditeur vérifié sur le domaine (ex: "noreply@drouet.io")
+
+interface Env {
+  RESEND_API_KEY: string;
+  CONTACT_TO: string;
+  CONTACT_FROM?: string;
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return text("Requête invalide", 400);
+  }
+
+  // Honeypot : un humain laisse "bot-field" vide ; un bot le remplit.
+  if (form.get("bot-field")) return text("OK", 200);
+
+  const name = clip(form.get("name"), 200);
+  const email = clip(form.get("email"), 200);
+  const subject = clip(form.get("subject"), 300);
+  const message = clip(form.get("message"), 5000);
+
+  if (!name || !email || !subject || !message) {
+    return text("Champs requis manquants", 400);
+  }
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    return text("Email invalide", 400);
+  }
+
+  if (!env.RESEND_API_KEY || !env.CONTACT_TO) {
+    return text("Service de contact non configuré", 503);
+  }
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      from: `cv.drouet.io <${env.CONTACT_FROM ?? "noreply@drouet.io"}>`,
+      to: env.CONTACT_TO,
+      reply_to: email,
+      subject: `Contact CV — ${subject}`,
+      text: `De : ${name} <${email}>\nSujet : ${subject}\n\n${message}`,
+    }),
+  });
+
+  return res.ok ? text("OK", 200) : text("Erreur d'envoi", 502);
+};
+
+function clip(value: FormDataEntryValue | null, max: number): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function text(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.6",
     "@astrojs/sitemap": "^3.6.0",
+    "@cloudflare/workers-types": "^4.20260529.1",
     "astro": "^6.1.9",
     "tailwindcss": "^4.1.11",
     "typescript": "^6.0.0"

--- a/src/components/ContactModal.astro
+++ b/src/components/ContactModal.astro
@@ -1,5 +1,5 @@
 ---
-// Contact Modal Component with Netlify Forms support
+// Contact Modal Component — submits to the Cloudflare Pages Function /api/contact
 ---
 
 <!-- Contact Modal -->
@@ -36,17 +36,13 @@
       </div>
 
       <!-- Contact Form -->
-      <form 
+      <form
         id="contact-form"
-        name="contact" 
-        method="POST" 
-        data-netlify="true" 
-        data-netlify-honeypot="bot-field"
+        name="contact"
+        method="POST"
+        action="/api/contact"
         class="space-y-4"
       >
-        <!-- Netlify Forms -->
-        <input type="hidden" name="form-name" value="contact" />
-        
         <!-- Honeypot field for spam protection -->
         <div class="hidden">
           <label>Don't fill this out if you're human: <input name="bot-field" /></label>
@@ -206,15 +202,15 @@
       try {
         // Create FormData
         const formData = new FormData(form);
-        
-        // Convert FormData to URLSearchParams for Netlify
+
+        // Convert FormData to URLSearchParams (form-urlencoded body)
         const params = new URLSearchParams();
         for (const [key, value] of formData.entries()) {
           params.append(key, value.toString());
         }
-        
-        // Submit to Netlify
-        const response = await fetch('/', {
+
+        // Submit to the Cloudflare Pages Function
+        const response = await fetch('/api/contact', {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: params.toString()

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "cv-mathieudrouet-2025"
+pages_build_output_dir = "dist"
+compatibility_date = "2026-05-29"


### PR DESCRIPTION
## Résumé

Migration du site (Astro SSG) de **Netlify** vers **Cloudflare Pages**, à iso-fonctionnalité. Cette PR contient **la spécification ET son implémentation**. Les fichiers Netlify sont conservés jusqu'au cutover DNS (rollback).

📄 Spécification : `docs/07-migration-cloudflare-pages-2026-05-29.md`

## Implémentation

| Fichier | Rôle |
|---------|------|
| `functions/_middleware.ts` | **Pages Function** — négociation Markdown (`Accept: text/markdown`), portée à l'identique de l'edge function Netlify |
| `functions/api/contact.ts` | **Pages Function** — backend formulaire de contact (envoi email via Resend), remplace Netlify Forms ; honeypot + validation conservés |
| `src/components/ContactModal.astro` | Retrait des attributs Netlify (`data-netlify*`, `form-name`), POST vers `/api/contact` |
| `wrangler.toml` | Config de déploiement Pages (`pages_build_output_dir = "dist"`) |
| `package.json` | Ajout `@cloudflare/workers-types` |
| `CLAUDE.md` | Doc mise à jour (formulaire, Pages Functions) |
| `public/_headers` | **Inchangé** — format nativement compatible, CSP conservée (POST same-origin) |

## Validation

- ✅ `bun run build` — OK (2 pages générées)
- ✅ `bun test` — 38/38 tests passent
- ℹ️ `astro check` : 2 erreurs **préexistantes** dans `src/pages/index.astro` (non liées à la migration ; `functions/` n'est pas analysé)

## À configurer avant cutover (côté Cloudflare Pages)

- Réglages build : `bun run build` → `dist`, `NODE_VERSION=22`
- Secrets formulaire : `RESEND_API_KEY`, `CONTACT_TO` (+ `CONTACT_FROM` optionnel)
- Domaine custom `cv.drouet.io` + bascule DNS (cf. §4 de la spec)
- Phase 0 : lever l'ambiguïté de lockfiles (`bun.lock` vs `package-lock.json`/`pnpm-lock.yaml`)

## Tests de bascule

Critères d'acceptation + commandes `curl` détaillés dans la spec (§6), à exécuter sur l'URL preview `*.pages.dev` **avant** le changement DNS.

## Hors périmètre (Phase 4 — après validation ≥ 1 semaine)

Suppression de `netlify.toml`, `netlify/edge-functions/`, et des lockfiles concurrents.

https://claude.ai/code/session_017GqfC7786VtYui9EMuSqBY